### PR TITLE
`no-guard`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This preset is recommended for projects that use [Fork API](https://effector.dev
 
 This preset is recommended for projects that use [React](https://reactjs.org) with Effector.
 
+#### plugin:effector/future
+
+This preset contains rules wich enforce _future-effector_ code-style.
+
 ### Supported rules
 
 - [effector/enforce-store-naming-convention](rules/enforce-store-naming-convention/enforce-store-naming-convention.md)
@@ -62,6 +66,7 @@ This preset is recommended for projects that use [React](https://reactjs.org) wi
 - [effector/no-unnecessary-combination](rules/no-unnecessary-combination/no-unnecessary-combination.md)
 - [effector/no-useless-methods](rules/no-useless-methods/no-useless-methods.md)
 - [effector/no-forward](rules/no-forward/no-forward.md)
+- [effector/no-guard](rules/no-guard/no-guard.md)
 - [effector/no-ambiguity-target](rules/no-ambiguity-target/no-ambiguity-target.md)
 - [effector/no-duplicate-on](rules/no-duplicate-on/no-duplicate-on.md)
 - [effector/no-getState](rules/no-getState/no-getState.md)

--- a/config/future.js
+++ b/config/future.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rules: {
+    "effector/prefer-sample-over-forward-with-mapping": "off",
+    "effector/no-forward": "warn",
+    "effector/no-guard": "warn",
+  },
+};

--- a/index.js
+++ b/index.js
@@ -14,10 +14,12 @@ module.exports = {
     "enforce-gate-naming-convention": require("./rules/enforce-gate-naming-convention/enforce-gate-naming-convention"),
     "keep-options-order": require("./rules/keep-options-order/keep-options-order"),
     "no-forward": require("./rules/no-forward/no-forward"),
+    "no-guard": require("./rules/no-forward/no-guard"),
   },
   configs: {
     recommended: require("./config/recommended"),
     scope: require("./config/scope"),
     react: require("./config/react"),
+    future: require("./config/future"),
   },
 };

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     "enforce-gate-naming-convention": require("./rules/enforce-gate-naming-convention/enforce-gate-naming-convention"),
     "keep-options-order": require("./rules/keep-options-order/keep-options-order"),
     "no-forward": require("./rules/no-forward/no-forward"),
-    "no-guard": require("./rules/no-forward/no-guard"),
+    "no-guard": require("./rules/no-guard/no-guard"),
   },
   configs: {
     recommended: require("./config/recommended"),

--- a/rules/no-guard/no-guard.js
+++ b/rules/no-guard/no-guard.js
@@ -1,22 +1,22 @@
 const { extractImportedFrom } = require("../../utils/extract-imported-from");
 const { createLinkToRule } = require("../../utils/create-link-to-rule");
 const { method } = require("../../utils/method");
-const { replaceForwardBySample } = require("../../utils/replace-by-sample");
+const { replaceGuardBySample } = require("../../utils/replace-by-sample");
 const { extractConfig } = require("../../utils/extract-config");
 
 module.exports = {
   meta: {
     type: "problem",
     docs: {
-      description: "Prefer `sample` over `forward`",
+      description: "Prefer `sample` over `guard`",
       category: "Quality",
       recommended: true,
-      url: createLinkToRule("no-forward"),
+      url: createLinkToRule("no-guard"),
     },
     messages: {
-      noForward:
-        "Instead of `forward` you can use `sample`, it is more extendable.",
-      replaceWithSample: "Repalce `forward` with `sample`.",
+      noGuard:
+        "Instead of `guard` you can use `sample`, it is more extendable.",
+      replaceWithSample: "Repalce `guard` with `sample`.",
     },
     schema: [],
     hasSuggestions: true,
@@ -36,7 +36,7 @@ module.exports = {
       },
       CallExpression(node) {
         if (
-          method.isNot("forward", {
+          method.isNot("guard", {
             node,
             importMap: importedFromEffector,
           })
@@ -44,20 +44,25 @@ module.exports = {
           return;
         }
 
-        const forwardConfig = extractConfig(["from", "to"], { node });
+        const guardConfig = extractConfig(
+          ["source", "clock", "target", "filter"],
+          {
+            node,
+          }
+        );
 
-        if (!forwardConfig.from || !forwardConfig.to) {
+        if (!guardConfig.clock || !guardConfig.filter) {
           return;
         }
 
         context.report({
-          messageId: "noForward",
+          messageId: "noGuard",
           node,
           suggest: [
             {
               messageId: "replaceWithSample",
               *fix(fixer) {
-                yield* replaceForwardBySample(forwardConfig, {
+                yield* replaceGuardBySample(guardConfig, {
                   fixer,
                   node,
                   context,

--- a/rules/no-guard/no-guard.md
+++ b/rules/no-guard/no-guard.md
@@ -22,7 +22,7 @@ guard({
 });
 
 // 👍 makes sense
-guard({
+sample({
   clock: trigger,
   soruce: $data,
   filter: Boolean,

--- a/rules/no-guard/no-guard.md
+++ b/rules/no-guard/no-guard.md
@@ -1,0 +1,32 @@
+# effector/no-guard
+
+Any `guard` call could be replaced with `sample` call.
+
+```ts
+// 👎 could be replaced
+guard({ clock: trigger, soruce: $data, filter: Boolean, target: reaction });
+
+// 👍 makes sense
+sample({ clock: trigger, source: $data, filter: Boolean, target: reaction });
+```
+
+Nice bonus: `sample` is extendable. You can add transformation by `fn`.
+
+```ts
+// 👎 could be replaced
+guard({
+  clock: trigger,
+  soruce: $data.map((data) => data.length),
+  filter: Boolean,
+  target: reaction,
+});
+
+// 👍 makes sense
+guard({
+  clock: trigger,
+  soruce: $data,
+  filter: Boolean,
+  fn: (data) => data.length,
+  target: reaction,
+});
+```

--- a/rules/no-guard/no-guard.test.js
+++ b/rules/no-guard/no-guard.test.js
@@ -1,0 +1,114 @@
+const { RuleTester } = require("eslint");
+
+const rule = require("./no-guard");
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("effector/no-guard.test", rule, {
+  valid: [
+    `
+import { sample } from 'effector';
+sample({ clock: eventOne, target: eventTwo });
+`,
+    `
+import { guard } from 'effector';
+guard({ clock: eventOne.map(() => true), target: eventTwo });
+`,
+    `
+import { guard } from 'someLibrary';
+forward({ clock: eventOne.prepend((v) => v.length), target: eventTwo });
+`,
+  ].map((code) => ({ code })),
+
+  invalid: [
+    {
+      code: `
+import { guard } from 'effector';
+guard({ clock: eventOne, target: eventTwo, filter: Boolean });
+`,
+      errors: [
+        {
+          messageId: "noGuard",
+          type: "CallExpression",
+          suggestions: [
+            {
+              messageId: "replaceWithSample",
+              output: `
+import { sample } from 'effector';
+sample({ clock: eventOne, filter: Boolean, target: eventTwo });
+`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+import { guard } from 'effector';
+guard({ clock: eventOne, target: eventTwo.prepend((v) => v.length), filter: (v) => v.length > 0 });
+`,
+      errors: [
+        {
+          messageId: "noGuard",
+          type: "CallExpression",
+          suggestions: [
+            {
+              messageId: "replaceWithSample",
+              output: `
+import { sample } from 'effector';
+sample({ clock: eventOne, filter: (v) => v.length > 0, fn: (v) => v.length, target: eventTwo });
+`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+import { guard } from 'effector';
+guard({ clock: eventOne, target: serviceOne.featureOne.eventTwo.prepend((v) => v.length), filter: $store });
+`,
+      errors: [
+        {
+          messageId: "noGuard",
+          type: "CallExpression",
+          suggestions: [
+            {
+              messageId: "replaceWithSample",
+              output: `
+import { sample } from 'effector';
+sample({ clock: eventOne, filter: $store, fn: (v) => v.length, target: serviceOne.featureOne.eventTwo });
+`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+import { guard } from 'effector';
+guard({ source: $someStore, clock: merge(eventOne, eventOneOne), target: eventTwo, filter: Boolean });
+`,
+      errors: [
+        {
+          messageId: "noGuard",
+          type: "CallExpression",
+          suggestions: [
+            {
+              messageId: "replaceWithSample",
+              output: `
+import { sample } from 'effector';
+sample({ clock: merge(eventOne, eventOneOne), source: $someStore, filter: Boolean, target: eventTwo });
+`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/rules/prefer-sample-over-forward-with-mapping/prefer-sample-over-forward-with-mapping.js
+++ b/rules/prefer-sample-over-forward-with-mapping/prefer-sample-over-forward-with-mapping.js
@@ -5,6 +5,7 @@ const {
 const { createLinkToRule } = require("../../utils/create-link-to-rule");
 const { method } = require("../../utils/method");
 const { replaceForwardBySample } = require("../../utils/replace-by-sample");
+const { extractConfig } = require("../../utils/extract-config");
 
 module.exports = {
   meta: {
@@ -48,12 +49,7 @@ module.exports = {
           return;
         }
 
-        const forwardConfig = {
-          from: node.arguments?.[0]?.properties.find(
-            (n) => n.key?.name === "from"
-          ),
-          to: node.arguments?.[0]?.properties.find((n) => n.key?.name === "to"),
-        };
+        const forwardConfig = extractConfig(["from", "to"], { node });
 
         if (!forwardConfig.from || !forwardConfig.to) {
           return;

--- a/utils/extract-config.js
+++ b/utils/extract-config.js
@@ -1,0 +1,13 @@
+function extractConfig(fields, { node }) {
+  const config = {};
+
+  fields.forEach((field) => {
+    config[field] = node.arguments?.[0]?.properties.find(
+      (n) => n.key?.name === field
+    );
+  });
+
+  return config;
+}
+
+module.exports = { extractConfig };


### PR DESCRIPTION
fixes #83 

- [x] imports
- [x] docs
- [x] config — `prefer-sample` (preset to enable `no-forward` and `no-guard`)