### PR TITLE
Fix store naming check

### DIFF
--- a/rules/enforce-store-naming-convention/prefix/enforce-store-naming-convention-prefix.test.js
+++ b/rules/enforce-store-naming-convention/prefix/enforce-store-naming-convention-prefix.test.js
@@ -75,5 +75,26 @@ const $store = createStore(null);
         },
       ],
     },
+    {
+      code: `
+import {createStore} from 'effector';
+const $store$ = createStore(null);
+          `,
+      errors: [
+        {
+          messageId: "invalidName",
+          suggestions: [
+            {
+              messageId: "renameStore",
+              data: { storeName: "$store$", correctedStoreName: "$store" },
+              output: `
+import {createStore} from 'effector';
+const $store = createStore(null);
+          `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });

--- a/rules/enforce-store-naming-convention/prefix/enforce-store-naming-convention-prefix.ts.test.js
+++ b/rules/enforce-store-naming-convention/prefix/enforce-store-naming-convention-prefix.ts.test.js
@@ -25,7 +25,9 @@ ruleTester.run(
   "effector/enforce-store-naming-convention-prefix.ts.test",
   rule,
   {
-    valid: ["correct-store-naming.ts"].map(readExampleForTheRule),
+    valid: ["correct-store-naming.ts", "correct-issue-139.ts"].map(
+      readExampleForTheRule
+    ),
 
     invalid: [
       // Errors

--- a/rules/enforce-store-naming-convention/prefix/examples/correct-issue-139.ts
+++ b/rules/enforce-store-naming-convention/prefix/examples/correct-issue-139.ts
@@ -1,0 +1,3 @@
+import { createStore } from "effector";
+
+const $ = createStore(0);

--- a/utils/get-corrected-store-name.js
+++ b/utils/get-corrected-store-name.js
@@ -5,17 +5,41 @@ function getCorrectedStoreName(storeName, context) {
 
   // handle edge case
   if (storeName.startsWith("$") && storeName.endsWith("$")) {
-    if (storeNameConvention === "prefix") {
-      return `$${storeName.slice(0, -1)}`;
-    } else {
-      return `${storeName.slice(1)}$`;
+    const storeNameWithoutConvention = trimByPattern(storeName, "$");
+    return formatStoreName(storeNameWithoutConvention, storeNameConvention);
+  }
+
+  const correctedStoreName = formatStoreName(storeName, storeNameConvention);
+
+  return correctedStoreName;
+}
+
+function formatStoreName(storeName, convention) {
+  return convention === "prefix" ? `$${storeName}` : `${storeName}$`;
+}
+
+function trimByPattern(s, template) {
+  let l = 0,
+    r = s.length - 1;
+
+  while (l <= r) {
+    const head = s[l];
+    const tail = s[r];
+
+    if (head === template) {
+      l++;
+    }
+
+    if (tail === template) {
+      r--;
+    }
+
+    if (head !== template && tail !== template) {
+      return s.slice(l, r + 1);
     }
   }
 
-  const correctedStoreName =
-    storeNameConvention === "prefix" ? `$${storeName}` : `${storeName}$`;
-
-  return correctedStoreName;
+  return s;
 }
 
 module.exports = { getCorrectedStoreName };

--- a/utils/naming.js
+++ b/utils/naming.js
@@ -14,7 +14,7 @@ function isStoreNameValid({ name, context }) {
   const storeNameConvention = getStoreNameConvention(context);
 
   // validate edge case
-  if (name?.startsWith("$") && name?.endsWith("$")) {
+  if (name?.length > 1 && name?.startsWith("$") && name?.endsWith("$")) {
     return false;
   }
 


### PR DESCRIPTION
fixes #139

Also, I noticed that if you use an entry like this

```ts
const $store$ = createStore(0) // fired with a suggestion rename it to `$$store`
```

<details>
  <summary>Screenshot</summary>

![image](https://github.com/effector/eslint-plugin/assets/82271383/7c4a41e0-f69f-4250-a938-87473ab57bc0)
</details>

I can fix it in this pr, сorrection option to the entry (if a prefix convention is used)

```ts
const $store$ = createStore(0) // suggestion: rename it to `$store`
```