### PR TITLE
[New] support all config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add `effector` to the plugins section of your `.eslintrc` configuration file. Yo
 ```json
 {
   "plugins": ["effector"],
-  "extends": ["plugin:effector/recommended", "plugin:effector/scope"]
+  "extends": ["plugin:effector/recommended", "plugin:effector/scope"] // or ["plugin:effector/all"] to use all rules
 }
 ```
 

--- a/config/all.js
+++ b/config/all.js
@@ -1,0 +1,16 @@
+const future = require("./future");
+const patronum = require("./patronum");
+const react = require("./react");
+const recommended = require("./recommended");
+const scope = require("./scope");
+
+module.exports = {
+  rules: Object.assign(
+    {},
+    future.rules,
+    patronum.rules,
+    react.rules,
+    recommended.rules,
+    scope.rules
+  ),
+};

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
     "no-patronum-debug": require("./rules/no-patronum-debug/no-patronum-debug"),
   },
   configs: {
+    all: require("./config/all"),
     recommended: require("./config/recommended"),
     scope: require("./config/scope"),
     react: require("./config/react"),


### PR DESCRIPTION
Instead of define each config separately, sometimes its convenient to just use all config. So instead of:

```json
{
  "plugins": ["effector"],
  "extends": ["plugin:effector/recommended", "plugin:effector/scope", ...]
}
```

we can do

```json
{
  "plugins": ["effector"],
  "extends": ["plugin:effector/all"]
}
```