### PR TITLE
Add test for false-positive of `no-duplicate-on` rule

### DIFF
--- a/rules/no-duplicate-on/examples/correct-with-factories.ts
+++ b/rules/no-duplicate-on/examples/correct-with-factories.ts
@@ -1,0 +1,17 @@
+// Example was found in production code-base with false-positive.
+
+import { createEvent, createStore } from "effector";
+
+function createField() {
+  return {
+    $value: createStore(""),
+  };
+}
+
+const change = createEvent<{ first: string; second: string }>();
+
+const firstField = createField();
+const secondField = createField();
+
+firstField.$value.on(change, (_, { first }) => first);
+secondField.$value.on(change, (_, { second }) => second);

--- a/rules/no-duplicate-on/no-duplicate-on.ts.test.js
+++ b/rules/no-duplicate-on/no-duplicate-on.ts.test.js
@@ -24,6 +24,7 @@ ruleTester.run("effector/no-duplicate-on.ts.test", rule, {
   valid: [
     "correct.ts",
     "correct-with-scopes.ts",
+    "correct-with-factories.ts",
     "correct-with-nesting.ts",
     "correct-with-empty-on.ts",
   ].map(readExampleForTheRule),


### PR DESCRIPTION
Example:

```ts
const change = createEvent<{ first: string; second: string }>();

const firstField = createField();
const secondField = createField();

firstField.$value.on(change, (_, { first }) => first);
// Error: Method `.on` is called on store `$value` more than once for change.
secondField.$value.on(change, (_, { second }) => second);
```

