### PR TITLE
Intermediate ESLint 9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ $ npm install --dev eslint-plugin-effector
 
 ## Usage
 
+### ESLint <= 8
+
 Add `effector` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
 
 ```json
@@ -38,6 +40,25 @@ Add `effector` to the plugins section of your `.eslintrc` configuration file. Yo
   "plugins": ["effector"],
   "extends": ["plugin:effector/recommended", "plugin:effector/scope"]
 }
+```
+
+### ESLint 9
+
+```mjs
+import { fixupPluginRules } from "@eslint/compat";
+import effector from "eslint-plugin-effector";
+
+export default [
+  {
+    plugins: {
+      effector: fixupPluginRules(effector),
+    },
+    rules: {
+      ...effector.configs.recommended.rules,
+      ...effector.configs.scope.rules,
+    },
+  },
+];
 ```
 
 Read more detailed docs on [eslint.effector.dev](https://eslint.effector.dev/)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^16 || ^17 || ^18 || ^19 || ^20 || ^21 || ^22"
+    "node": "^16 || ^17 || ^18 || ^19 || ^20 || ^21 || ^22 || ^23"
   },
   "devDependencies": {
     "@types/react": "^17.0.37",
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "effector": "^23",
-    "eslint": "7 || 8"
+    "eslint": "7 || 8 || 9"
   },
   "dependencies": {
     "prettier": "^2.3.2"


### PR DESCRIPTION
Until here's no official support for ESLint 9, it's should not throw peer dependency error for ESLint 9 users