### PR TITLE
Mark Node.js 24 and below as supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
+        node-version: [16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^16 || ^17 || ^18 || ^19 || ^20 || ^21 || ^22"
+    "node": ">=16 <25"
   },
   "devDependencies": {
     "@types/react": "^17.0.37",


### PR DESCRIPTION
After [updating](https://nodejs.org/en/blog/release/v24.11.0) the LTS version of Node.js, it will be useful to support it in the plugin.